### PR TITLE
Bump react peer dependency to allow v14 and v15

### DIFF
--- a/package.json
+++ b/package.json
@@ -122,7 +122,7 @@
     "lodash.debounce": "^3.1.1",
     "react-highlighter": "^0.3.0",
     "react-json-tree": "^0.5.1",
-    "react-responsive": "^1.0.1",
+    "react-responsive": "^1.1.2",
     "redux-devtools-themes": "^1.0.0"
   }
 }

--- a/package.json
+++ b/package.json
@@ -115,7 +115,7 @@
     "webpack-dev-server": "^1.14.0"
   },
   "peerDependencies": {
-    "react": "^0.14.0",
+    "react": "^0.14.0 || ^15.0.0",
     "redux-devtools": "^3.0.0"
   },
   "dependencies": {


### PR DESCRIPTION
It looks like [react-json-tree](https://github.com/alexkuz/react-json-tree)'s latest version bump enabled support for v15, but I'm not sure if there's breaking changes between 0.5 to 0.6.

I also sent a PR to react-highlighter and react-responsive to get em to bump the peer dependency. Even though it doesn't prevent users from updating, the warning is annoying and it could potentially make you miss other stuff.

EDIT: Bumped react-responsive to v1.1.2 as well, since my PR was accepted and merged.
