### PR TITLE
Added auto scroll to the end after store update (by closed issues/31)

### DIFF
--- a/source/FilterableLogMonitor.js
+++ b/source/FilterableLogMonitor.js
@@ -30,6 +30,8 @@ export default class FilterableLogMonitor extends Component {
     theme: 'nicinabox'
   }
 
+  static isMouseOver = false;
+
   componentWillReceiveProps (nextProps) {
     const { actionsById, dispatch, stagedActionIds } = this.props
 
@@ -41,6 +43,12 @@ export default class FilterableLogMonitor extends Component {
 
         dispatch(addActionMetadata({ action, actionId, appState }))
       }
+    }
+  }
+
+  componentDidUpdate () {
+    if (!this.isMouseOver) {
+      this.refs.wrapper.scrollTop = this.refs.container.offsetHeight
     }
   }
 
@@ -103,6 +111,8 @@ export default class FilterableLogMonitor extends Component {
           fontSize: 14,
           minWidth: 200
         }}
+        onMouseOver={(e) => this.isMouseOver = true}
+        onMouseOut={(e) => this.isMouseOver = false}
       >
         <ActionFilter
           actionFilterText={actionFilterText}
@@ -110,12 +120,13 @@ export default class FilterableLogMonitor extends Component {
           theme={theme}
         />
         <div
+          ref='wrapper'
           style={{
             flex: '1',
             overflowY: 'scroll'
           }}
         >
-          {filterableStates}
+          <div ref='container'>{filterableStates}</div>
         </div>
       </div>
     )

--- a/source/FilterableLogMonitor.js
+++ b/source/FilterableLogMonitor.js
@@ -30,7 +30,10 @@ export default class FilterableLogMonitor extends Component {
     theme: 'nicinabox'
   }
 
-  static isMouseOver = false;
+  constructor (props) {
+    super(props)
+    this.isAutoScrollEnabled = true
+  }
 
   componentWillReceiveProps (nextProps) {
     const { actionsById, dispatch, stagedActionIds } = this.props
@@ -47,7 +50,7 @@ export default class FilterableLogMonitor extends Component {
   }
 
   componentDidUpdate () {
-    if (!this.isMouseOver) {
+    if (this.isAutoScrollEnabled) {
       this.wrapperNode.scrollTop = this.containerNode.offsetHeight
     }
   }
@@ -125,7 +128,13 @@ export default class FilterableLogMonitor extends Component {
             flex: '1',
             overflowY: 'scroll'
           }}
-        >
+          onScroll={() => {
+            if (this.wrapperNode.scrollTop + this.wrapperNode.offsetHeight >= this.containerNode.offsetHeight) {
+              this.isAutoScrollEnabled = true
+              return
+            }
+            this.isAutoScrollEnabled = false
+          }}>
           <div ref={(node) => { this.containerNode = node }} >{filterableStates}</div>
         </div>
       </div>

--- a/source/FilterableLogMonitor.js
+++ b/source/FilterableLogMonitor.js
@@ -113,10 +113,7 @@ export default class FilterableLogMonitor extends Component {
           color: theme.base07,
           fontSize: 14,
           minWidth: 200
-        }}
-        onMouseOver={(e) => this.isMouseOver = true}
-        onMouseOut={(e) => this.isMouseOver = false}
-      >
+        }}>
         <ActionFilter
           actionFilterText={actionFilterText}
           dispatch={dispatch}

--- a/source/FilterableLogMonitor.js
+++ b/source/FilterableLogMonitor.js
@@ -48,7 +48,7 @@ export default class FilterableLogMonitor extends Component {
 
   componentDidUpdate () {
     if (!this.isMouseOver) {
-      this.refs.wrapper.scrollTop = this.refs.container.offsetHeight
+      this.wrapperNode.scrollTop = this.containerNode.offsetHeight
     }
   }
 
@@ -120,13 +120,13 @@ export default class FilterableLogMonitor extends Component {
           theme={theme}
         />
         <div
-          ref='wrapper'
+          ref={(node) => { this.wrapperNode = node }}
           style={{
             flex: '1',
             overflowY: 'scroll'
           }}
         >
-          <div ref='container'>{filterableStates}</div>
+          <div ref={(node) => { this.containerNode = node }} >{filterableStates}</div>
         </div>
       </div>
     )

--- a/website/Application.css
+++ b/website/Application.css
@@ -42,6 +42,10 @@ a:hover {
   background-color: #000000;
 }
 
+.Label{
+  margin-right: .5em;
+}
+
 .update {
   color: #6FB3D2;
   margin-right: .5em;

--- a/website/Application.js
+++ b/website/Application.js
@@ -5,6 +5,18 @@ import React, { Component } from 'react'
 import PropTypes from 'prop-types'
 import styles from './Application.css'
 
+const timeoutUpdater = function (enable, methodA, methodB) {
+  if (!enable) {
+    return clearTimeout(timeoutUpdater.timerId)
+  }
+
+  (Math.random() > 0.5) ? methodA() : methodB()
+
+  timeoutUpdater.timerId = setTimeout(() => {
+    timeoutUpdater(enable, methodA, methodB)
+  }, 10)
+}
+
 class Application extends Component {
   static propTypes = {
     udpateArray: PropTypes.func.isRequired,
@@ -39,6 +51,10 @@ class Application extends Component {
         </ul>
 
         <p>
+          <label className={styles.Label}>
+            <input type='checkbox' onChange={(e) => (timeoutUpdater(e.target.checked, udpateArray, udpateMap))}/>
+            Auto update (every 10 ms)
+          </label>
           <UpdateButton
             label='Array'
             labelClass='array'

--- a/website/Application.js
+++ b/website/Application.js
@@ -5,16 +5,17 @@ import React, { Component } from 'react'
 import PropTypes from 'prop-types'
 import styles from './Application.css'
 
-const timeoutUpdater = function (enable, methodA, methodB) {
+const timeoutUpdater = function (enable, updateMethodsList) {
   if (!enable) {
     return clearTimeout(timeoutUpdater.timerId)
   }
 
-  (Math.random() > 0.5) ? methodA() : methodB()
+  const updateMethod = updateMethodsList[Math.floor(Math.random() * updateMethodsList.length)]
+  updateMethod()
 
   timeoutUpdater.timerId = setTimeout(() => {
-    timeoutUpdater(enable, methodA, methodB)
-  }, 10)
+    timeoutUpdater(enable, updateMethodsList)
+  }, 1000)
 }
 
 class Application extends Component {
@@ -33,6 +34,7 @@ class Application extends Component {
 
   render () {
     const { udpateArray, udpateList, udpateMap, udpateObject } = this.props
+    const autoUpdateMethods = [ udpateArray, udpateList, udpateMap, udpateObject ]
 
     return (
       <div className={styles.Application}>
@@ -52,8 +54,8 @@ class Application extends Component {
 
         <p>
           <label className={styles.Label}>
-            <input type='checkbox' onChange={(e) => (timeoutUpdater(e.target.checked, udpateArray, udpateMap))}/>
-            Auto update (every 10 ms)
+            <input type='checkbox' onChange={(e) => (timeoutUpdater(e.target.checked, autoUpdateMethods))}/>
+            Auto update (every 1s)
           </label>
           <UpdateButton
             label='Array'


### PR DESCRIPTION
Hello! We use your library in project.
And we really needed auto scroll to last action (if panel is not over).
I see closed [issue](https://github.com/bvaughn/redux-devtools-filterable-log-monitor/issues/31)  and i see, you were not against it, so, i'm make it. 

Added auto scroll to the end after store update (by closed issues/31).
Added new test auto-trigger button.