### PR TITLE
This commit accounts for differences in JSONTree's renderer callbacks.

### DIFF
--- a/source/components/FilterableState.js
+++ b/source/components/FilterableState.js
@@ -44,8 +44,8 @@ export default function FilterableState ({
   } = monitorStateAction
 
   const labelRenderer = filterByKeys && filterText
-    ? value => highlightMatches(filterText, value)
-    : value => value
+    ? value => highlightMatches(filterText, value[0])
+    : value => value[0]
 
   const valueRenderer = filterByValues && filterText
     ? (value, nodeType) => highlightMatches(filterText, value)


### PR DESCRIPTION
valueRenderer: passes a scalar value as an argument to the callback you provide.
labelRenderer: passes a array value as an argument to the callback you provide.
               This array value is the key ancestry of the json tree.

The Problem:
===
The name formating issue in FilterableState.js was caused by rendering the
**entire** key ancestry array as a string for every key, instead of just the name of the key.

Example:
when trying to render the "child" from this piece of state
```javascript
{
  grandParent: {
    parent: {
      child: { /*...*/ }
    }
  }
}
```

the `labelRenderer` callback, you provided, will be given the key and its ancestry as a value.
```javascript
function labelRenderer (value) {
  // value == ["child", "parent", "grandParent"]
  return value;
}
```

`JSONTree` takes the return of `labelRenderer` and renders it as a
string. So the above return value becomes "childparentgrandParent".

This is why you get the visual bug in the preview of state for the LogMonitor.

The Solution:
===
return the first key, instead of the entire key ancestry, to get the
correctly formatted label.